### PR TITLE
Optimized global history layout.

### DIFF
--- a/src/wiki/plugins/globalhistory/templates/wiki/plugins/globalhistory/globalhistory.html
+++ b/src/wiki/plugins/globalhistory/templates/wiki/plugins/globalhistory/globalhistory.html
@@ -10,6 +10,9 @@
 {% spaceless %}
 <div class="row">
   <div class="lead col-xs-12">
+    {% with paginator.object_list.count as cnt %}
+       {% blocktrans %}List of all <strong>{{ cnt }} changes</strong> in the wiki.{% endblocktrans %}
+    {% endwith %}
     <div class="pull-right">
       <a class="btn btn-default"
          {% if only_last == "1" %}
@@ -21,76 +24,54 @@
          {% endif %}
       </a>
     </div>
-    {% with paginator.object_list.count as cnt %}
-       {% blocktrans %}List of all <strong>{{ cnt }} changes</strong> in the wiki.{% endblocktrans %}
-    {% endwith %}
   </div>
 </div>
 
 <div class="row">
-  <div class="col-sm-12">
   {% if revisions %}
-    <table class="table table-bordered table-striped table-condensed table-hover">
+    <table class="table table-striped table-condensed table-hover">
       <thead>
         <tr>
-          <th>{% trans "Revision ID" %}</th>
+          <th>{% trans "Revision" %}</th>
           <th>{% trans "Article" %}</th>
-          <th>{% trans "Message" %}</th>
-          <th>{% trans "User" %}</th>
-          <th>{% trans "Date" %}</th>
-          <th></th>
         </tr>
       </thead>
 
       <tbody>
-        {% for article_revision in revisions %}
+        {% for revision in revisions %}
           <tr>
             <td>
-              {{ article_revision.revision_number }}
-            </td>
-            <td>
-              <a href="{% url 'wiki:get' article_revision.article.pk %}">
-                {{ article_revision.article }}
-              </a>
-            </td>
-            <td>
-              {% if article_revision.user_message %}
-                {{ article_revision.user_message }}
-              {% elif article_revision.automatic_log %}
-                {{ article_revision.automatic_log }}
+              <span style="white-space:nowrap">#{{ revision.revision_number }}: {{ revision.modified }}</span>
+              {% trans "by" %}&nbsp;{% spaceless %}
+              {% if revision.user %}{{ revision.user }}
+              {% else %}{% if revision.article|can_moderate:user %}{{ revision.ip_address|default:"anonymous (IP not logged)" }}
+              {% else %}{% trans "anonymous (IP logged)" %}{% endif %}{% endif %}
+              {% endspaceless %}
+              {% if revision.deleted %}
+                <span class="badge badge-important">{% trans "deleted" %}</span>
+              {% endif %}
+              {% if revision.previous_revision.deleted and not revision.deleted %}
+                <span class="badge badge-success">{% trans "restored" %}</span>
+              {% endif %}
+              {% if revision.locked %}
+                <span class="badge">{% trans "locked" %}</span>
+              {% endif %}
+              {% if revision.previous_revision.locked and not revision.locked %}
+                <span class="badge">{% trans "unlocked" %}</span>
+              {% endif %}
+              <br>
+              {% if revision.user_message %}
+                {{ revision.user_message }}
+              {% elif revision.automatic_log %}
+                {{ revision.automatic_log }}
               {% else %}
                 ({% trans "no log message" %})
               {% endif %}
-              {% if article_revision.deleted %}
-                <span class="badge badge-important">{% trans "deleted" %}</span>
-              {% endif %}
-              {% if article_revision.previous_revision.deleted and not article_revision.deleted %}
-                <span class="badge badge-success">{% trans "restored" %}</span>
-              {% endif %}
-              {% if article_revision.locked %}
-                <span class="badge">{% trans "locked" %}</span>
-              {% endif %}
-              {% if article_revision.previous_revision.locked and not revision.locked %}
-                <span class="badge">{% trans "unlocked" %}</span>
-              {% endif %}
             </td>
             <td>
-              {% if article_revision.user %}
-                {{ article_revision.user }}
-              {% else %}
-                {% if article_revision.article|can_moderate:user %}
-                  {{ article_revision.ip_address|default:"anonymous (IP not logged)" }}
-                {% else %}
-                  {% trans "anonymous (IP logged)" %}i
-                {% endif %}
-              {% endif %}
-            </td>
-            <td>
-              {{article_revision.modified}}
-            </td>
-            <td class="text-right">
-              <a href="{% url 'wiki:history' article_revision.article.pk %}" class="btn btn-info btn-xs">{% trans "Go to article history" %}</a>
-              <a href="{% url 'wiki:get' article_revision.article.pk %}" class="btn btn-primary btn-xs">{% trans "Go to article" %}</a>
+              <a href="{% url 'wiki:get' revision.article.pk %}" class="btn btn-primary btn-xs">{% trans "Article "%}"{{ revision.article }}"</a>
+              <br>
+              <a href="{% url 'wiki:history' revision.article.pk %}" class="btn btn-info btn-xs">{% trans "Article history" %}</a>
             </td>
           </tr>
         {% endfor %}
@@ -108,7 +89,6 @@
   {% endif %}
 
   {% include "wiki/includes/pagination.html" %}
-</div>
 </div>
 {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
Optimized layout so that it behaves better on small devices:
- Use one instead of four columns for all revision related information.
- Don't duplicate the article link.
- If there is not enough space show the "List of..." text in an own line.
- Maximize horizontal space for the table.

Image of the current layout:

![image](https://user-images.githubusercontent.com/27075192/32406260-98a23c60-c14b-11e7-8c89-531bee95436a.png)
